### PR TITLE
Add macOS support to podspec.

### DIFF
--- a/BCryptSwift.podspec
+++ b/BCryptSwift.podspec
@@ -43,6 +43,7 @@ The `verifyPassword(matchesHash:)` class convenience function will hash the pass
 
   s.ios.deployment_target = '9.0'
   s.tvos.deployment_target = '9.0'
+  s.osx.deployment_target = '10.9'
 
   s.source_files = 'BCryptSwift/Classes/**/*'
 


### PR DESCRIPTION
This one-line change to the podspec allows the pod to be used in macOS apps. No code changes were necessary.